### PR TITLE
just produce a Date if dtstart/end are dates

### DIFF
--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -253,7 +253,13 @@ defmodule ICalendar.Util.Deserialize do
   end
 
   def to_date(date_string, %{"VALUE" => "DATE"}) do
-    to_date(date_string <> "T000000Z")
+    # to_date(date_string <> "T000000Z")
+    date_string = if String.last(date_string) == "Z", do: date_string, else: date_string <> "Z"
+
+    case Timex.parse(date_string, "{YYYY}{0M}{0D}Z") do
+      {:ok, date} -> {:ok, Timex.to_date(date)}
+      error -> error
+    end
   end
 
   def to_date(date_string, %{}) do


### PR DESCRIPTION
short of changing a lot of assumptions and flow this is the easiest way to provide a differentiation of all-day vs. specific time events for clients to make decisions.